### PR TITLE
FIX: add get account by id endpoint

### DIFF
--- a/src/modules/accounts/accounts.controller.js
+++ b/src/modules/accounts/accounts.controller.js
@@ -18,6 +18,22 @@ async function listAccounts(req, res, next) {
     }
 }
 
+async function getAccountById(req, res, next) {
+    try {
+        const { id } = req.params;
+
+        const result = await accountsService.getAccountById(id);
+
+        if (!result) {
+            return res.status(404).json({ message: "Account not found" });
+        }
+
+        res.json(result);
+    } catch (err) {
+        next(err);
+    }
+}
+
 async function updateAccount(req, res, next) {
     try {
         const result = await accountsService.updateAccount(req.params.id, req.body);
@@ -40,5 +56,6 @@ module.exports = {
     createAccount,
     listAccounts,
     updateAccount,
+    getAccountById,
     deleteAccount
 };

--- a/src/modules/accounts/accounts.routes.js
+++ b/src/modules/accounts/accounts.routes.js
@@ -9,6 +9,9 @@ router.post('/', accountsController.createAccount);
 // Listar contas
 router.get('/', accountsController.listAccounts);
 
+// Buscar pelo id
+router.get('/:id', accountsController.getAccountById);
+
 // Atualizar conta
 router.put('/:id', accountsController.updateAccount);
 

--- a/src/modules/accounts/accounts.service.js
+++ b/src/modules/accounts/accounts.service.js
@@ -42,9 +42,18 @@ async function deleteAccount(id) {
     });
 }
 
+async function getAccountById(id) {
+    return prisma.account.findUnique({
+        where: {
+            id: Number(id)
+        }
+    });
+}
+
 module.exports = {
     createAccount,
     listAccounts,
     updateAccount,
+    getAccountById,
     deleteAccount
 };


### PR DESCRIPTION
### Summary
Add missing endpoint to fetch an account by id.

### Details
The frontend edit modal requires a `GET /api/accounts/:id` request to load account data.
This endpoint did not exist, causing a 404 error and preventing the modal from opening.

### Changes
- Added `getAccountById` method to accounts controller
- Added `GET /api/accounts/:id` route

### Result
- Edit account modal now opens correctly
- Account data is properly loaded